### PR TITLE
Updating static semantics and grammar

### DIFF
--- a/grammar/grammar.tex
+++ b/grammar/grammar.tex
@@ -25,6 +25,8 @@
 \newcommand\code[1]{\ensuremath{\text{\texttt{#1}}}}
 \renewcommand\arg[1]{\ensuremath{\mathit{#1}}}
 \newcommand\angles[1]{\langle #1 \rangle}
+\newcommand\sanchor{\cmd{\ensuremath{{}^\land}}}
+\newcommand\eanchor{\cmd{\$}}
 
 % Swap \epsilon and \varepsilon
 \let\oldepsilon\epsilon \let\epsilon\varepsilon \let\varepsilon\oldepsilon
@@ -54,10 +56,12 @@ Functions judged \J{fun0} cannot take addresses, those judged \J{fun1} can take 
 	\RULE{a_1\ \J{basead} \qquad a_2\ \J{basead} \qquad f\ \J{fun2}}{\angles{a_1, a_2, f}\ \J{cmd}} \qquad
 	\RULE{a_1\ \J{basead} \qquad a_2\ \J{basead} \qquad f\ \J{fun2}}{\angles{a_1, a_2, \cmd{!}, f}\ \J{cmd}}
 \end{gather*}
+%
 Commands can be nested in blocks:
 \begin{gather*}
 	\RULE{\arg{cmds}\ \J{sed}}{\cmd{\{} \arg{cmds} \cmd{\}}\ \J{fun2}}
 \end{gather*}
+%
 Functions that (optionally) take a label:
 \begin{gather*}
 	\RULE{\arg{label}\ \J{label}}{\cmd{:}\ \arg{label}\ \J{fun0}} \qquad
@@ -66,6 +70,7 @@ Functions that (optionally) take a label:
 	\RULE{\arg{label}\ \J{label}}{\cmd{t}\ \arg{label}\ \J{fun2}} \qquad
 	\RULE{}{\cmd{t}\ \J{fun2}}
 \end{gather*}
+%
 Simple functions that take no arguments: (Note that \cmd{q} and \cmd{=} are 1-address functions.)
 \begin{gather*}
 	\RULE{}{\cmd{d}\ \J{fun2}} \qquad
@@ -82,31 +87,49 @@ Simple functions that take no arguments: (Note that \cmd{q} and \cmd{=} are 1-ad
 	\RULE{}{\cmd{x}\ \J{fun2}} \qquad
 	\RULE{}{\cmd{=}\ \J{fun1}}
 \end{gather*}
+%
 Some commands take a text argument:
 \begin{gather*}
 	\RULE{\arg{text}\ \J{str}}{\cmd{a}\ \arg{text}\ \J{fun1}} \qquad
 	\RULE{\arg{text}\ \J{str}}{\cmd{i}\ \arg{text}\ \J{fun1}} \qquad
 	\RULE{\arg{text}\ \J{str}}{\cmd{c}\ \arg{text}\ \J{fun2}}
 \end{gather*}
+%
 Finally, the text manipulation commands:
 \begin{gather*}
-	\RULE{\arg{pat}\ \J{regex} \qquad \arg{repl}\ \J{str} \qquad \arg{flags}\ \J{sflags}}{\cmd{s}\ \arg{pat}\ \arg{repl}\ \arg{sflags}\ \J{fun2}} \qquad
+	\RULE{\arg{pat}\ \J{regex} \qquad \arg{repl}\ \J{regrepl} \qquad \arg{flags}\ \J{sflags}}{\cmd{s}\ \cmd{/}\arg{pat}\cmd{/}\ \arg{repl}\ \arg{sflags}\ \J{fun2}} \qquad
 	\RULE{\arg{pat}\ \J{str} \qquad \arg{repl}\ \J{str}}{\cmd{y}\ \arg{pat}\ \arg{repl}\ \J{fun2}}
 \end{gather*}
+%
+Regular expressions are a sub-language, mostly following the POSIX BRE specification\footnote{\url{https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html}} (without collating features; note that bracket expressions (a.k.a.\ character classes) just accept a list of characters in this grammar, which is only a loss of convenience and not of expressivity):
+\begin{gather*}
+	\RULE{}{\epsilon\ \J{regex}} \qquad
+	\RULE{\arg{item}\ \J{regitem} \qquad \arg{r}\ \J{regex}}{\arg{item}\ \arg{r}\ \J{regex}} \\
+	\RULE{c\ \J{char}}{c\ \J{regitem}} \qquad
+	\RULE{\arg{chars}\ \J{str}}{\cmd{[} \arg{chars} \cmd{]}\ \J{regitem}} \qquad
+	\RULE{n \in \mathbb{Z}_{\geq0}}{\cmd{\textbackslash} n\ \J{regitem}} \qquad
+	\RULE{}{\sanchor\ \J{regitem}} \qquad
+	\RULE{}{\eanchor\ \J{regitem}} \\
+	\RULE{\arg{reg}\ \J{regex}}{(\arg{reg})\ \J{regitem}} \qquad
+	\RULE{\arg{reg}\ \J{regex}}{\arg{reg}^*\ \J{regitem}} \qquad
+	\RULE{\arg{reg}\ \J{regex} \qquad n,m \in \mathbb{Z}_{\geq0}}{\arg{reg}\cmd{\{}n\cmd{,}m\cmd{\}}\ \J{regitem}} \qquad
+\end{gather*}
+%
 Base addresses are specified as follows:
 \begin{gather*}
 	\RULE{n \in \mathbb{Z}_{\geq 1}}{n\ \J{basead}} \qquad
 	\RULE{}{\cmd{\$}\ \J{basead}} \qquad
 	\RULE{\arg{reg}\ \J{regex}}{\arg{reg}\ \J{basead}} \qquad
 \end{gather*}
+%
 The following auxiliary judgements are used:
 \begin{gather*}
 	\RULE{}{\code{""}\ \J{str}} \qquad
 	\RULE{c\ \J{char} \qquad s\ \J{str}}{(c : s)\ \J{str}} \\
 	\RULE{\exists n : (n \in \mathbb{Z}_{\geq1} \land \arg{flags} \in \{\epsilon,\, n,\, \cmd{g},\, \cmd{p},\, n\ \cmd{p},\, \cmd{p}\ n,\, \cmd{g}\ \cmd{p},\, \cmd{p}\ \cmd{g}\})}{\arg{flags}\ \J{sflags}}
 \end{gather*}
+%
 The ``label'' judgement defines a set of values on which only an equivalence relation (equality) is required.
-The ``regex'' judgement defines the set of accepted regular expressions, which for now is kept abstract.
 The ``char'' judgement defines the set of characters, which has no particular requirements except that this set needs to be finite.
 
 

--- a/grammar/grammar.tex
+++ b/grammar/grammar.tex
@@ -102,7 +102,7 @@ Base addresses are specified as follows:
 The following auxiliary judgements are used:
 \begin{gather*}
 	\RULE{}{\epsilon\ \J{str}} \qquad
-	\RULE{c\ \J{char} \qquad s\ \J{str}}{c\ s\ \J{str}} \\
+	\RULE{c\ \J{char} \qquad s\ \J{str}}{(c : s)\ \J{str}} \\
 	\RULE{\exists n : (n \in \mathbb{Z}_{\geq1} \land \arg{flags} \in \{\epsilon,\, n,\, \cmd{g},\, \cmd{p},\, n\ \cmd{p},\, \cmd{p}\ n,\, \cmd{g}\ \cmd{p},\, \cmd{p}\ \cmd{g}\})}{\arg{flags}\ \J{sflags}}
 \end{gather*}
 The ``label'' judgement defines a set of values on which only an equivalence relation (equality) is required.

--- a/grammar/grammar.tex
+++ b/grammar/grammar.tex
@@ -39,18 +39,20 @@ Note that these rules do not yet define the static semantics, only an abstract r
 Note also that the programs defined by this rule set form a strict subset of the programs specified by the official \SED{} specification\footnote{\url{https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sed.html}}, since the \texttt{l}, \texttt{r}, \texttt{w} and \texttt{\#} commands are missing, as well as an \texttt{s} flag.
 
 
-A program consists of commands, which consist of an address and a function.
-Functions can take a varying number of addresses, though a function can always take less addresses than specified.
+A program consists of commands, which consist of a function and possibly zero, one or two addresses.
+Functions judged \J{fun0} cannot take addresses, those judged \J{fun1} can take at most 1 address, and those judged \J{fun2} can take zero, one or two addresses.
 \begin{gather*}
 	\RULE{}{\epsilon\ \J{sed}} \qquad
 	\RULE{c\ \J{cmd} \qquad s\ \J{sed}}{c\ s\ \J{sed}} \\
-	\RULE{\arg{f}\ \J{fun}}{\angles{\epsilon, f}\ \J{cmd}} \qquad
-	\RULE{a\ \J{addr1} \qquad f\ \J{fun1}}{\angles{a, f}\ \J{cmd}} \qquad
-	\RULE{a\ \J{addr1} \qquad f\ \J{fun2}}{\angles{a, f}\ \J{cmd}} \qquad
-	\RULE{a\ \J{addr2} \qquad f\ \J{fun2}}{\angles{a, f}\ \J{cmd}} \\
-	\RULE{\arg{f}\ \J{fun0}}{\arg{f}\ \J{fun}} \qquad
-	\RULE{\arg{f}\ \J{fun1}}{\arg{f}\ \J{fun}} \qquad
-	\RULE{\arg{f}\ \J{fun2}}{\arg{f}\ \J{fun}}
+	\RULE{\arg{f}\ \J{fun0}}{f\ \J{cmd}} \qquad
+	\RULE{\arg{f}\ \J{fun1}}{f\ \J{cmd}} \qquad
+	\RULE{\arg{f}\ \J{fun2}}{f\ \J{cmd}} \\
+	\RULE{a\ \J{basead} \qquad f\ \J{fun1}}{\angles{a, f}\ \J{cmd}} \qquad
+	\RULE{a\ \J{basead} \qquad f\ \J{fun1}}{\angles{a, \cmd{!}, f}\ \J{cmd}} \\
+	\RULE{a\ \J{basead} \qquad f\ \J{fun2}}{\angles{a, f}\ \J{cmd}} \qquad
+	\RULE{a\ \J{basead} \qquad f\ \J{fun2}}{\angles{a, \cmd{!}, f}\ \J{cmd}} \\
+	\RULE{a_1\ \J{basead} \qquad a_2\ \J{basead} \qquad f\ \J{fun2}}{\angles{a_1, a_2, f}\ \J{cmd}} \qquad
+	\RULE{a_1\ \J{basead} \qquad a_2\ \J{basead} \qquad f\ \J{fun2}}{\angles{a_1, a_2, \cmd{!}, f}\ \J{cmd}}
 \end{gather*}
 Commands can be nested in blocks:
 \begin{gather*}
@@ -86,39 +88,26 @@ Some commands take a text argument:
 	\RULE{\arg{text}\ \J{str}}{\cmd{i}\ \arg{text}\ \J{fun1}} \qquad
 	\RULE{\arg{text}\ \J{str}}{\cmd{c}\ \arg{text}\ \J{fun2}}
 \end{gather*}
-Finally, the substitution commands:
+Finally, the text manipulation commands:
 \begin{gather*}
 	\RULE{\arg{pat}\ \J{regex} \qquad \arg{repl}\ \J{str} \qquad \arg{flags}\ \J{sflags}}{\cmd{s}\ \arg{pat}\ \arg{repl}\ \arg{sflags}\ \J{fun2}} \qquad
 	\RULE{\arg{pat}\ \J{str} \qquad \arg{repl}\ \J{str}}{\cmd{y}\ \arg{pat}\ \arg{repl}\ \J{fun2}}
 \end{gather*}
-Addresses are specified as follows:
+Base addresses are specified as follows:
 \begin{gather*}
-	\RULE{}{\epsilon\ \J{addr}} \qquad
-	\RULE{\arg{addr}\ \J{addr1}}{\arg{addr}\ \J{addr}} \qquad
-	\RULE{\arg{addr}\ \J{addr2}}{\arg{addr}\ \J{addr}} \\
-	\RULE{\arg{addr}\ \J{basead} \qquad \arg{neg}\ \J{adneg}}{\arg{addr}\ \arg{neg}\ \J{addr1}} \qquad
-	\RULE{}{\epsilon\ \J{addr1}} \\
-	\RULE{a_1\ \J{basead} \qquad a_2\ \J{basead} \qquad \arg{neg}\ \J{adneg}}{a_1,a_2\ \arg{neg}\ \J{addr2}} \qquad
-	\RULE{\arg{addr}\ \J{addr1}}{\arg{addr}\ \J{addr2}} \\
 	\RULE{n \in \mathbb{Z}_{\geq 1}}{n\ \J{basead}} \qquad
 	\RULE{}{\cmd{\$}\ \J{basead}} \qquad
 	\RULE{\arg{reg}\ \J{regex}}{\arg{reg}\ \J{basead}} \qquad
-	\RULE{}{\epsilon\ \J{adneg}} \qquad
-	\RULE{}{\cmd{!}\ \J{adneg}}
 \end{gather*}
-Where the following auxiliary judgements are used:
+The following auxiliary judgements are used:
 \begin{gather*}
 	\RULE{}{\epsilon\ \J{str}} \qquad
-	\RULE{c\ \J{char} \qquad s\ \J{str}}{c\ s\ \J{str}} \qquad
-	\RULE{n \in \mathbb{Z} \qquad 0 \leq n \leq 255}{n\ \J{char}} \\
-	\RULE{}{\cmd{g}\ \J{sflag}} \qquad
-	\RULE{}{\cmd{p}\ \J{sflag}} \qquad
-	\RULE{n \in \mathbb{Z}_{\geq 1}}{n\ \J{sflag}} \qquad
-	\RULE{}{\epsilon\ \J{sflags}} \qquad
-	\RULE{f\ \J{sflag} \qquad r\ \J{sflags}}{f\ r\ \J{sflags}}
+	\RULE{c\ \J{char} \qquad s\ \J{str}}{c\ s\ \J{str}} \\
+	\RULE{\exists n : (n \in \mathbb{Z}_{\geq1} \land \arg{flags} \in \{\epsilon,\, n,\, \cmd{g},\, \cmd{p},\, n\ \cmd{p},\, \cmd{p}\ n,\, \cmd{g}\ \cmd{p},\, \cmd{p}\ \cmd{g}\})}{\arg{flags}\ \J{sflags}}
 \end{gather*}
 The ``label'' judgement defines a set of values on which only an equivalence relation (equality) is required.
 The ``regex'' judgement defines the set of accepted regular expressions, which for now is kept abstract.
+The ``char'' judgement defines the set of characters, which has no particular requirements except that this set needs to be finite.
 
 
 \end{document}

--- a/grammar/grammar.tex
+++ b/grammar/grammar.tex
@@ -115,6 +115,14 @@ Regular expressions are a sub-language, mostly following the POSIX BRE specifica
 	\RULE{\arg{reg}\ \J{regex} \qquad n,m \in \mathbb{Z}_{\geq0}}{\arg{reg}\cmd{\{}n\cmd{,}m\cmd{\}}\ \J{regitem}} \qquad
 \end{gather*}
 %
+Replacement strings in an \cmd{s} command contain backreferences:
+\begin{gather*}
+	\RULE{}{\epsilon\ \J{regrepl}} \qquad
+	\RULE{c\ \J{char} \qquad s\ \J{regrepl}}{c\ s\ \J{regrepl}} \qquad
+	\RULE{n \in \mathbb{Z}_{\geq0} \qquad s\ \J{regrepl}}{\cmd{\textbackslash}n\ s\ \J{regrepl}} \qquad
+	\RULE{s\ \J{regrepl}}{\cmd{\&}\ s\ \J{regrepl}}
+\end{gather*}
+%
 Base addresses are specified as follows:
 \begin{gather*}
 	\RULE{n \in \mathbb{Z}_{\geq 1}}{n\ \J{basead}} \qquad

--- a/grammar/grammar.tex
+++ b/grammar/grammar.tex
@@ -101,7 +101,7 @@ Base addresses are specified as follows:
 \end{gather*}
 The following auxiliary judgements are used:
 \begin{gather*}
-	\RULE{}{\epsilon\ \J{str}} \qquad
+	\RULE{}{\code{""}\ \J{str}} \qquad
 	\RULE{c\ \J{char} \qquad s\ \J{str}}{(c : s)\ \J{str}} \\
 	\RULE{\exists n : (n \in \mathbb{Z}_{\geq1} \land \arg{flags} \in \{\epsilon,\, n,\, \cmd{g},\, \cmd{p},\, n\ \cmd{p},\, \cmd{p}\ n,\, \cmd{g}\ \cmd{p},\, \cmd{p}\ \cmd{g}\})}{\arg{flags}\ \J{sflags}}
 \end{gather*}

--- a/semantics/static.tex
+++ b/semantics/static.tex
@@ -32,63 +32,52 @@
 
 \section{Static semantics}
 
-Define the following abstraction for \SED{} programs:
-\begin{gather*}
-	\RULE{}{\epsilon\ \J{sed}} \qquad
-	\RULE{c\ \J{cmd} \qquad s\ \J{sed}}{c\ s\ \J{sed}} \\
-	\RULE{}{\cmd{b}\ \arg{\ell}\ \J{cmd}} \qquad
-	\RULE{}{\cmd{:}\ \arg{\ell}\ \J{cmd}} \qquad
-	\RULE{s\ \J{sed}}{\cmd{\{}\ s\ \cmd{\}}\ \J{cmd}} \qquad
-	\RULE{\arg{pat}\ \J{ypat} \qquad \arg{repl}\ \J{str}}{\cmd{y}\ \arg{pat}\ \arg{repl}\ \J{cmd}} \qquad
-	\RULE{}{\cmd{C}\ \J{cmd}}
-\end{gather*}
-where \cmd{:}, \cmd{\{}\ldots\!\cmd{\}} and \cmd{y} (for `ypat' and `str', see the grammar) model their counterparts in the actual \SED{} grammar, \cmd{b} models all label-referencing commands (\cmd{b} and \cmd{t}), and \cmd{C} is any other command.
-We abstract over addresses; these are not relevant in the static checking.
-
-\textbf{TODO: Need to add rules that prove the above judgements for the relevant commands in the actual grammar, so that the ``intuitive'' description above is unnecessary (and only useful for auxiliary description). Then `cmd' and `sed' need to be renamed in this document so as to not conflict with the judgements in the full grammar.}
-
 We say a \SED{} program is correct according to the static semantics if the `ok' judgement can be proven of it.
 This is true if it is both \textbf{l}abel-\textbf{c}orrect and \textbf{y}-\textbf{c}orrect:
 \begin{gather*}
 	\RULE{s\ \J{sed} \qquad s\ \J{lc} \qquad s\ \J{yc}}{s\ \J{ok}}
 \end{gather*}
+%
 A program is label-correct if it refers only to labels defined elsewhere in the program.
 \begin{gather*}
 	\RULE{s\ \J{labels}\ L \qquad L \vdash s\ \J{lc'}}{s\ \J{lc}}
 \end{gather*}
-This we do by first collecting all the labels:
+%
+This we do by first collecting all the labels (and verifying that they are unique):
 \begin{gather*}
 	\RULE{}{\epsilon\ \J{labels}\ \emptyset} \qquad
-	\RULE{s\ \J{labels}\ L \qquad \ell \not\in L}{(\cmd{:}\ \ell)\ s\ \J{labels}\ \{\ell\} \cup L} \qquad
-	\RULE{s_1\ s\ \J{labels}\ L}{\cmd{\{} s_1 \cmd{\}}\ s\ \J{labels}\ L} \\
+	\RULE{s\ \J{labels}\ L \qquad \ell \not\in L}{((\cmd{:}\ \ell)\ s)\ \J{labels}\ \{\ell\} \cup L} \\
 %
-	\RULE{s\ \J{labels}\ L}{(\cmd{b}\ \ell)\ s\ \J{labels}\ L} \qquad
-	\RULE{s\ \J{labels}\ L}{(\cmd{y}\ \arg{pat}\ \arg{repl})\ s\ \J{labels}\ L} \qquad
-	\RULE{s\ \J{labels}\ L}{\cmd{C}\ s\ \J{labels}\ L}
+	\RULE{(s_1\ s)\ \J{labels}\ L}{(\cmd{\{} s_1 \cmd{\}}\ s)\ \J{labels}\ L} \qquad
+	\RULE{(\arg{fun}\ s)\ \J{labels}\ L}{(\angles{\ldots, \arg{fun}}\ s)\ \J{labels}\ L} \qquad
+	\RULE{s\ \J{labels}\ L}{(\text{\underline{anything else}}\ s)\ \J{labels}\ L}
 \end{gather*}
+The ``$\angles{\ldots, \arg{fun}}$'' should be understood to match any command with an address of any form (1- or 2-part, and negated or not negated) and function \arg{fun}.
+The ``\underline{anything else}'' should be understood to match anything that is not a label, a block or a command with an address.
+
 Then, we verify that all label-referencing instructions only refer to labels that we have collected:
 \begin{gather*}
 	\RULE{}{L \vdash \epsilon\ \J{lc'}} \qquad
 	\RULE{\ell \in L \qquad L \vdash s\ \J{lc'}}{L \vdash (\cmd{b}\ \ell)\ s\ \J{lc'}} \qquad
-	\RULE{L \vdash s_1\ \J{lc'} \qquad L \vdash s\ \J{lc'}}{L \vdash \cmd{\{} s_1 \cmd{\}}\ s\ \J{lc'}} \\
+	\RULE{\ell \in L \qquad L \vdash s\ \J{lc'}}{L \vdash (\cmd{t}\ \ell)\ s\ \J{lc'}} \\
 %
-	\RULE{L \vdash s\ \J{lc'}}{L \vdash (\cmd{:}\ \ell)\ s\ \J{lc'}} \qquad
-	\RULE{L \vdash s\ \J{lc'}}{L \vdash (\cmd{y}\ \arg{pat}\ \arg{repl})\ s\ \J{lc'}} \qquad
-	\RULE{L \vdash s\ \J{lc'}}{L \vdash \cmd{C}\ s\ \J{lc'}}
+	\RULE{L \vdash s_1\ \J{lc'} \qquad L \vdash s\ \J{lc'}}{L \vdash \cmd{\{} s_1 \cmd{\}}\ s\ \J{lc'}} \qquad
+	\RULE{L \vdash \arg{fun}\ s\ \J{lc'}}{L \vdash \angles{\ldots, \arg{fun}}\ s\ \J{lc'}} \qquad
+	\RULE{L \vdash s\ \J{lc'}}{L \vdash \text{\underline{anything else}}\ s\ \J{lc'}}
 \end{gather*}
+The ``\underline{anything else}'' should be understood to match anything that is not a \cmd{b} or \cmd{t} command, a block, or a command with an address.
+
 A program is y-correct if for each \cmd{y}-instruction in the program, the pattern and replacement have equal length and the pattern does not contain duplicate characters:
 \begin{gather*}
 	\RULE{}{\epsilon\ \J{yc}} \qquad
-	\RULE{|\arg{pat}| = |\arg{repl}| \qquad \arg{pat}\ \J{nodup} \qquad s\ \J{yc}}{(\cmd{y}\ \arg{pat}\ \arg{repl})\ s\ \J{yc}} \qquad
-	\RULE{s_1\ \J{yc} \qquad s\ \J{yc}}{\cmd{\{} s_1 \cmd{\}}\ s\ \J{yc}} \\
+	\RULE{|\arg{pat}| = |\arg{repl}| \qquad \arg{pat}\ \J{nodup} \qquad s\ \J{yc}}{((\cmd{y}\ \arg{pat}\ \arg{repl})\ s)\ \J{yc}} \\
 %
-	\RULE{s\ \J{yc}}{(\cmd{b}\ \ell)\ s\ \J{yc}} \qquad
-	\RULE{s\ \J{yc}}{(\cmd{:}\ \ell)\ s\ \J{yc}} \qquad
-	\RULE{s\ \J{yc}}{\cmd{C}\ s\ \J{yc}} \\
+	\RULE{s_1\ \J{yc} \qquad s\ \J{yc}}{(\cmd{\{} s_1 \cmd{\}}\ s)\ \J{yc}} \qquad
+	\RULE{(\arg{fun}\ s)\ \J{yc}}{(\angles{\ldots, \arg{fun}}\ s)\ \J{yc}} \\
 	\RULE{}{\epsilon\ \J{nodup}} \qquad
-	\RULE{c\ s\ \J{str} \qquad c\ \J{notin}\ s \qquad s\ \J{nodup}}{c\ s\ \J{nodup}} \\
+	\RULE{(c\ s)\ \J{str} \qquad c\ \J{notin}\ s \qquad s\ \J{nodup}}{(c\ s)\ \J{nodup}} \\
 	\RULE{c\ \J{char}}{c\ \J{notin}\ \epsilon} \qquad
-	\RULE{c\ \J{char} \qquad c'\ s\ \J{str} \qquad c \not= c' \qquad c\ \J{notin}\ s}{c\ \J{notin}\ c'\ s}
+	\RULE{c\ \J{char} \qquad (c'\ s)\ \J{str} \qquad c \not= c' \qquad c\ \J{notin}\ s}{c\ \J{notin}\ (c'\ s)}
 \end{gather*}
 
 

--- a/semantics/static.tex
+++ b/semantics/static.tex
@@ -22,6 +22,8 @@
 \newcommand\code[1]{\ensuremath{\text{\texttt{#1}}}}
 \renewcommand\arg[1]{\ensuremath{\mathit{#1}}}
 \newcommand\angles[1]{\langle #1 \rangle}
+\newcommand\sanchor{\cmd{\ensuremath{{}^\land}}}
+\newcommand\eanchor{\cmd{\$}}
 
 % Swap \epsilon and \varepsilon
 \let\oldepsilon\epsilon \let\epsilon\varepsilon \let\varepsilon\oldepsilon
@@ -33,9 +35,9 @@
 \section{Static semantics}
 
 We say a \SED{} program is correct according to the static semantics if the `ok' judgement can be proven of it.
-This is true if it is both \textbf{l}abel-\textbf{c}orrect and \textbf{y}-\textbf{c}orrect:
+This is true if it is \textbf{l}abel-\textbf{c}orrect, \textbf{y}-\textbf{c}orrect and \textbf{r}egex-\textbf{c}orrect:
 \begin{gather*}
-	\RULE{s\ \J{sed} \qquad s\ \J{lc} \qquad s\ \J{yc}}{s\ \J{ok}}
+	\RULE{s\ \J{sed} \qquad s\ \J{lc} \qquad s\ \J{yc} \qquad s\ \J{rc}}{s\ \J{ok}}
 \end{gather*}
 %
 A program is label-correct if it refers only to labels defined elsewhere in the program.
@@ -78,6 +80,44 @@ A program is y-correct if for each \cmd{y}-instruction in the program, the patte
 	\RULE{(c\ s)\ \J{str} \qquad c\ \J{notin}\ s \qquad s\ \J{nodup}}{(c\ s)\ \J{nodup}} \\
 	\RULE{c\ \J{char}}{c\ \J{notin}\ \epsilon} \qquad
 	\RULE{c\ \J{char} \qquad (c'\ s)\ \J{str} \qquad c \not= c' \qquad c\ \J{notin}\ s}{c\ \J{notin}\ (c'\ s)}
+\end{gather*}
+%
+A program is regex-correct if each address regular expression is regex-correct' (with any number of capture groups) and each \cmd{s} command is \textbf{s}-\textbf{c}orrect.
+\begin{gather*}
+	\RULE{}{\epsilon\ \J{rc}} \qquad
+	\RULE{\arg{a_1}\ \J{rc'}\ \arg{n} \qquad (\arg{fun}\ \arg{s})\ \J{rc}}{(\angles{\arg{a_1}, (\cmd{!},)^?, \arg{fun}}\ s)\ \J{rc}} \qquad
+	\RULE{\arg{a_1}\ \J{rc'}\ \arg{n} \qquad \arg{a_2}\ \J{rc'}\ \arg{m} \qquad (\arg{fun}\ s)\ \J{rc}}{(\angles{\arg{a_1}, \arg{a_2}, (\cmd{!},)^?, \arg{fun}}\ s)\ \J{rc}} \\
+	\RULE{(\cmd{s}\ \arg{reg}\ \arg{repl}\ \arg{flags})\ \J{sc}}{((\cmd{s}\ \arg{reg}\ \arg{repl}\ \arg{flags})\ \arg{s})\ \J{rc}} \qquad
+	\RULE{s\ \J{rc}}{(\text{\underline{anything else}}\ s)\ \J{rc}}
+\end{gather*}
+The element ``$(\cmd{!},)^?$'' should be understood to be an optional ``\cmd{!},''; i.e.\ those rules matches both negated and non-negated addresses.
+The ``\underline{anything else}'' should be understood to match anything that is not a command with an address or an \cmd{s} command.
+
+An \cmd{s} command is s-correct if its regular expression is regex-correct' and the backreferences in its replacement only refer to existing capture groups.
+The \J{rc'} judgement checks regex integrity and returns the number of capture groups, which the \J{replc} (\textbf{repl}acement-\textbf{c}orrect) judgement uses to verify the replacement.
+\begin{gather*}
+	\RULE{\arg{reg}\ \J{rc'}\ \arg{n} \qquad \arg{repl}\ \J{replc}\ n}{(\cmd{s}\ \arg{reg}\ \arg{repl}\ \arg{flags})\ \J{sc}}
+\end{gather*}
+%
+The \J{rc'} judgement loops over the regular expression \emph{backwards}, and verifies backreferences and interval-expressions.
+\begin{gather*}
+	\RULE{}{\epsilon\ \J{rc'}\ 0} \qquad
+	\RULE{r\ \J{rc'}\ n \qquad k \leq n}{(r\ \cmd{\textbackslash} k)\ \J{rc'}\ n} \qquad
+	\RULE{(r\ \arg{r_1})\ \J{rc'}\ n}{(r\ (\arg{r_1}))\ \J{rc'}\ (n + 1)} \qquad
+	\RULE{(r\ \arg{r_1})\ \J{rc'}\ n \qquad \arg{k_1} \leq \arg{k_2}}{(r\ \arg{r_1}\cmd{\{}\arg{k_1}\cmd{,}\arg{k_2}\cmd{\}})\ \J{rc'}\ n} \\
+	\RULE{c\ \J{char} \qquad r\ \J{rc'}\ n}{(r\ c)\ \J{rc'}\ n} \qquad
+	\RULE{r\ \J{rc'}\ n}{(r\ \cmd{[} \arg{chars} \cmd{]})\ \J{rc'}\ n} \qquad
+	\RULE{(r\ \arg{r_1})\ \J{rc'}\ n}{(r\ \arg{r_1}^*)\ \J{rc'}\ n} \\
+	\RULE{r\ \J{rc'}\ n}{(r\ \sanchor)\ \J{rc'}\ n} \qquad
+	\RULE{r\ \J{rc'}\ n}{(r\ \eanchor)\ \J{rc'}\ n}
+\end{gather*}
+%
+The \J{replc} judgement checks the validity of backreferences in a replacement specification.
+\begin{gather*}
+	\RULE{}{\epsilon\ \J{replc}\ n} \qquad
+	\RULE{k \leq n \qquad s\ \J{replc}\ n}{(\cmd{\textbackslash} k\ s)\ \J{replc}\ n} \qquad
+	\RULE{c\ \J{char} \qquad s\ \J{replc}\ n}{(c\ s)\ \J{replc}\ n} \qquad
+	\RULE{s\ \J{replc}\ n}{(\cmd{\&}\ s)\ \J{replc}\ n}
 \end{gather*}
 
 

--- a/semantics/static.tex
+++ b/semantics/static.tex
@@ -13,12 +13,15 @@
 \usepackage{cleveref}
 \usepackage{float}
 
-\newcommand\RULE[2]{\begin{array}{c} #1 \\ \hline #2 \end{array}}
 \newcommand\SED{\emph{sed}}
-% a judgement
-\newcommand\J[1]{\ensuremath{\text{ #1}}}
+\newcommand\RULE[3][]{\begin{array}{c} #2 \\ \hline #3 \end{array}}
+\newcommand\data[1]{\ensuremath{\text{#1}}}
+\newcommand\field[1]{\ensuremath{\text{#1}}}
+\newcommand\J[1]{\ensuremath{\textbf{#1}}}
 \newcommand\cmd[1]{\ensuremath{\text{\texttt{#1}}}}
+\newcommand\code[1]{\ensuremath{\text{\texttt{#1}}}}
 \renewcommand\arg[1]{\ensuremath{\mathit{#1}}}
+\newcommand\angles[1]{\langle #1 \rangle}
 
 % Swap \epsilon and \varepsilon
 \let\oldepsilon\epsilon \let\epsilon\varepsilon \let\varepsilon\oldepsilon
@@ -31,13 +34,13 @@
 
 Define the following abstraction for \SED{} programs:
 \begin{gather*}
-	\RULE{}{\epsilon \J{sed}} \qquad
-	\RULE{c \J{cmd} \qquad s \J{sed}}{c\ s \J{sed}} \\
-	\RULE{}{\cmd{b}\ \arg{\ell} \J{cmd}} \qquad
-	\RULE{}{\cmd{:}\ \arg{\ell} \J{cmd}} \qquad
-	\RULE{s \J{sed}}{\cmd{\{}\ s\ \cmd{\}} \J{cmd}} \qquad
-	\RULE{\arg{pat} \J{ypat} \qquad \arg{repl} \J{str}}{\cmd{y}\ \arg{pat}\ \arg{repl} \J{cmd}} \qquad
-	\RULE{}{\cmd{C} \J{cmd}}
+	\RULE{}{\epsilon\ \J{sed}} \qquad
+	\RULE{c\ \J{cmd} \qquad s\ \J{sed}}{c\ s\ \J{sed}} \\
+	\RULE{}{\cmd{b}\ \arg{\ell}\ \J{cmd}} \qquad
+	\RULE{}{\cmd{:}\ \arg{\ell}\ \J{cmd}} \qquad
+	\RULE{s\ \J{sed}}{\cmd{\{}\ s\ \cmd{\}}\ \J{cmd}} \qquad
+	\RULE{\arg{pat}\ \J{ypat} \qquad \arg{repl}\ \J{str}}{\cmd{y}\ \arg{pat}\ \arg{repl}\ \J{cmd}} \qquad
+	\RULE{}{\cmd{C}\ \J{cmd}}
 \end{gather*}
 where \cmd{:}, \cmd{\{}\ldots\!\cmd{\}} and \cmd{y} (for `ypat' and `str', see the grammar) model their counterparts in the actual \SED{} grammar, \cmd{b} models all label-referencing commands (\cmd{b} and \cmd{t}), and \cmd{C} is any other command.
 We abstract over addresses; these are not relevant in the static checking.
@@ -47,45 +50,45 @@ We abstract over addresses; these are not relevant in the static checking.
 We say a \SED{} program is correct according to the static semantics if the `ok' judgement can be proven of it.
 This is true if it is both \textbf{l}abel-\textbf{c}orrect and \textbf{y}-\textbf{c}orrect:
 \begin{gather*}
-	\RULE{s \J{sed} \qquad s \J{lc} \qquad s \J{yc}}{s \J{ok}}
+	\RULE{s\ \J{sed} \qquad s\ \J{lc} \qquad s\ \J{yc}}{s\ \J{ok}}
 \end{gather*}
 A program is label-correct if it refers only to labels defined elsewhere in the program.
 \begin{gather*}
-	\RULE{s \J{labels}\ L \qquad L \vdash s \J{lc'}}{s \J{lc}}
+	\RULE{s\ \J{labels}\ L \qquad L \vdash s\ \J{lc'}}{s\ \J{lc}}
 \end{gather*}
 This we do by first collecting all the labels:
 \begin{gather*}
-	\RULE{}{\epsilon \J{labels}\ \emptyset} \qquad
-	\RULE{s \J{labels}\ L \qquad \ell \not\in L}{(\cmd{:}\ \ell)\ s \J{labels}\ \{\ell\} \cup L} \qquad
-	\RULE{s_1\ s \J{labels}\ L}{\cmd{\{} s_1 \cmd{\}}\ s \J{labels}\ L} \\
+	\RULE{}{\epsilon\ \J{labels}\ \emptyset} \qquad
+	\RULE{s\ \J{labels}\ L \qquad \ell \not\in L}{(\cmd{:}\ \ell)\ s\ \J{labels}\ \{\ell\} \cup L} \qquad
+	\RULE{s_1\ s\ \J{labels}\ L}{\cmd{\{} s_1 \cmd{\}}\ s\ \J{labels}\ L} \\
 %
-	\RULE{s \J{labels}\ L}{(\cmd{b}\ \ell)\ s \J{labels}\ L} \qquad
-	\RULE{s \J{labels}\ L}{(\cmd{y}\ \arg{pat}\ \arg{repl})\ s \J{labels}\ L} \qquad
-	\RULE{s \J{labels}\ L}{\cmd{C}\ s \J{labels}\ L}
+	\RULE{s\ \J{labels}\ L}{(\cmd{b}\ \ell)\ s\ \J{labels}\ L} \qquad
+	\RULE{s\ \J{labels}\ L}{(\cmd{y}\ \arg{pat}\ \arg{repl})\ s\ \J{labels}\ L} \qquad
+	\RULE{s\ \J{labels}\ L}{\cmd{C}\ s\ \J{labels}\ L}
 \end{gather*}
 Then, we verify that all label-referencing instructions only refer to labels that we have collected:
 \begin{gather*}
-	\RULE{}{L \vdash \epsilon \J{lc'}} \qquad
-	\RULE{\ell \in L \qquad L \vdash s \J{lc'}}{L \vdash (\cmd{b}\ \ell)\ s \J{lc'}} \qquad
-	\RULE{L \vdash s_1 \J{lc'} \qquad L \vdash s \J{lc'}}{L \vdash \cmd{\{} s_1 \cmd{\}}\ s \J{lc'}} \\
+	\RULE{}{L \vdash \epsilon\ \J{lc'}} \qquad
+	\RULE{\ell \in L \qquad L \vdash s\ \J{lc'}}{L \vdash (\cmd{b}\ \ell)\ s\ \J{lc'}} \qquad
+	\RULE{L \vdash s_1\ \J{lc'} \qquad L \vdash s\ \J{lc'}}{L \vdash \cmd{\{} s_1 \cmd{\}}\ s\ \J{lc'}} \\
 %
-	\RULE{L \vdash s \J{lc'}}{L \vdash (\cmd{:}\ \ell)\ s \J{lc'}} \qquad
-	\RULE{L \vdash s \J{lc'}}{L \vdash (\cmd{y}\ \arg{pat}\ \arg{repl})\ s \J{lc'}} \qquad
-	\RULE{L \vdash s \J{lc'}}{L \vdash \cmd{C}\ s \J{lc'}}
+	\RULE{L \vdash s\ \J{lc'}}{L \vdash (\cmd{:}\ \ell)\ s\ \J{lc'}} \qquad
+	\RULE{L \vdash s\ \J{lc'}}{L \vdash (\cmd{y}\ \arg{pat}\ \arg{repl})\ s\ \J{lc'}} \qquad
+	\RULE{L \vdash s\ \J{lc'}}{L \vdash \cmd{C}\ s\ \J{lc'}}
 \end{gather*}
 A program is y-correct if for each \cmd{y}-instruction in the program, the pattern and replacement have equal length and the pattern does not contain duplicate characters:
 \begin{gather*}
-	\RULE{}{\epsilon \J{yc}} \qquad
-	\RULE{|\arg{pat}| = |\arg{repl}| \qquad \arg{pat} \J{nodup} \qquad s \J{yc}}{(\cmd{y}\ \arg{pat}\ \arg{repl})\ s \J{yc}} \qquad
-	\RULE{s_1 \J{yc} \qquad s \J{yc}}{\cmd{\{} s_1 \cmd{\}}\ s \J{yc}} \\
+	\RULE{}{\epsilon\ \J{yc}} \qquad
+	\RULE{|\arg{pat}| = |\arg{repl}| \qquad \arg{pat}\ \J{nodup} \qquad s\ \J{yc}}{(\cmd{y}\ \arg{pat}\ \arg{repl})\ s\ \J{yc}} \qquad
+	\RULE{s_1\ \J{yc} \qquad s\ \J{yc}}{\cmd{\{} s_1 \cmd{\}}\ s\ \J{yc}} \\
 %
-	\RULE{s \J{yc}}{(\cmd{b}\ \ell)\ s \J{yc}} \qquad
-	\RULE{s \J{yc}}{(\cmd{:}\ \ell)\ s \J{yc}} \qquad
-	\RULE{s \J{yc}}{\cmd{C}\ s \J{yc}} \\
-	\RULE{}{\epsilon \J{nodup}} \qquad
-	\RULE{c\ s \J{str} \qquad c \J{notin}\ s \qquad s \J{nodup}}{c\ s \J{nodup}} \\
-	\RULE{c \J{char}}{c \J{notin}\ \epsilon} \qquad
-	\RULE{c \J{char} \qquad c'\ s \J{str} \qquad c \not= c' \qquad c \J{notin}\ s}{c \J{notin}\ c'\ s}
+	\RULE{s\ \J{yc}}{(\cmd{b}\ \ell)\ s\ \J{yc}} \qquad
+	\RULE{s\ \J{yc}}{(\cmd{:}\ \ell)\ s\ \J{yc}} \qquad
+	\RULE{s\ \J{yc}}{\cmd{C}\ s\ \J{yc}} \\
+	\RULE{}{\epsilon\ \J{nodup}} \qquad
+	\RULE{c\ s\ \J{str} \qquad c\ \J{notin}\ s \qquad s\ \J{nodup}}{c\ s\ \J{nodup}} \\
+	\RULE{c\ \J{char}}{c\ \J{notin}\ \epsilon} \qquad
+	\RULE{c\ \J{char} \qquad c'\ s\ \J{str} \qquad c \not= c' \qquad c\ \J{notin}\ s}{c\ \J{notin}\ c'\ s}
 \end{gather*}
 
 


### PR DESCRIPTION
Number of commits, relating to both the static semantics and the grammar. Most
changes relate to regular expressions and their validity.

Grammar render: https://tomsmeding.com/vang/0z08w6n/grammar.pdf

Static semantics render: https://tomsmeding.com/vang/0z0jw6o/static.pdf